### PR TITLE
Add optional ID parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
     global.loadJS = factory();
   }
 })(this, function() {
-  function loadScript(url) {
+  function loadScript(url, id) {
     var head   = document.getElementsByTagName("head")[0] || document.documentElement;
     var script = document.createElement("script");
 
@@ -18,6 +18,10 @@
     script.setAttribute("charset", "utf-8");
     script.setAttribute("type",    "text/javascript");
     script.setAttribute("src",     url);
+
+    if (id) {
+      script.id = id;
+    }
 
     //
     // Code from:


### PR DESCRIPTION
This allows for a user to pass in an optional ID parameter to add to the script tag in case they need to reference it later.  

A sample use case is in the event that the browser does not support document.currentScript and the script needs to be self-referencing to get its source.

Since load-js sets async to true on the scripts, the following snippet would potentially fail
```
var currentScript = document.currentScript || (function() {
      var scripts = document.getElementsByTagName('script');
      return scripts[scripts.length - 1];
    })();
// from http://www.2ality.com/2014/05/current-script.html
```
