### PR TITLE
Reject promise when script tag has an error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@
   }
 
   function loadScript(head, script) {
-    return new Promise(function(resolve) {
+    return new Promise(function(resolve, reject) {
       // Handle Script loading
       var done = false;
 
@@ -86,6 +86,7 @@
           resolve(script);
         }
       };
+      script.onerror = reject;
 
       head.appendChild(script);
     });


### PR DESCRIPTION
I added a line that makes the script-loading promise reject if the script has an error. This allows users to listen for errors using `.catch(...)` and handle them however they want.