### PR TITLE
Suppress logging to console as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ loadJS is a method that loads scripts concurrently using script tags. loadJS tak
 - `text`: Script text to execute. Required if no `url` is provided.
 - `cache`: flag to determine if item with ID or URL is to be cached. defaults to `true`.
 - `allowExternal`: flag to handle situations when the DOM already has a script element with the same ID or URL as what loadJS is being told to load. By default, loadJS will use script elements that already exist in the DOM. To turn off this behavior, set `allowExternal` to false.
+- `debug`: flag to show debug message. defaults to `false`.
 
 Some of these options are described in detail [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
 

--- a/src/load-js.js
+++ b/src/load-js.js
@@ -5,7 +5,8 @@ function createLoadJS() {
   function exec(options) {
     if (typeof options === "string") {
       options = {
-        url: options
+        url: options,
+        debug: false
       };
     }
 
@@ -13,7 +14,9 @@ function createLoadJS() {
     var cacheEntry = cache[cacheId];
 
     if (cacheEntry) {
-      console.log("load-js: cache hit", cacheId);
+      if (!!options.debug) {
+        console.log("load-js: cache hit", cacheId);
+      }
       return cacheEntry;
     }
     else if (options.allowExternal !== false) {


### PR DESCRIPTION
refs: https://github.com/MiguelCastillo/load-js/issues/28

I'd like to change default logging as false. what do you think? 